### PR TITLE
Initial GCE specialisation of the vanilla pc-gadget

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,14 @@
+name: testing
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  snap:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: snapcore/action-build@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 parts/
 prime/
 stage/
-pc_*.snap
+gce-gadget_*.snap
+gadget.yaml

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # 64bit PC Gadget Snap
 
-This repository contains the official Ubuntu Core gadget snap for 64bit
-Personal Computers using Intel or AMD processors. 
+This repository contains the official Ubuntu Core gadget snap for Google Cloud (GCE) VMs.
 
 ## Gadget Snaps
 
@@ -12,7 +11,7 @@ https://github.com/snapcore/snapd/wiki/Gadget-snap
 ## Reporting Issues
 
 Please report all issues on the Launchpad project page
-https://bugs.launchpad.net/snap-pc/+filebug
+https://bugs.launchpad.net/cloud-images/+filebug
 
 We use Launchpad to track issues as this allows us to coordinate multiple
 projects better than what is available with Github issues.
@@ -20,15 +19,3 @@ projects better than what is available with Github issues.
 ## Building
 
 To build the gadget snap locally please use `snapcraft`.
-
-## Launchpad Mirror and Automatic Builds.
-
-All commits from the master branch of https://github.com/snapcore/pc-amd64
-are automatically mirrored by Launchpad to the https://launchpad.net/snap-pc
-project.
-
-The master branch is automatically built from the launchpad mirror and
-published into the snap store to the edge channel.
-
-You can find build history and other controls here:
-https://code.launchpad.net/~canonical-foundations/+snap/pc-amd64

--- a/cloud.conf
+++ b/cloud.conf
@@ -1,0 +1,4 @@
+#cloud-config
+datasource:
+  GCE:
+    sec_between_retries: 5

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -8,6 +8,7 @@ description: |
 confinement: strict
 grade: stable
 icon: icon.png
+license: GPL-3.0-or-later
 
 #package-repositories:
 # - type: apt

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,10 +1,10 @@
-name: pc
-version: '24-0.2'
+name: gce-gadget
+version: '24-0.1'
 type: gadget
 base: core24
-summary: PC gadget for generic devices
+summary: GCE gadget for instances launched in Google Cloud
 description: |
-    This gadget enables generic pc devices to work with Ubuntu Core
+    This gadget enables GCE VMs to run Ubuntu Core
 confinement: strict
 grade: stable
 icon: icon.png
@@ -96,3 +96,8 @@ parts:
       # We need to install directly in the project dir as snapcraft checks there
       # for gadget.yaml instead of looking first at the prime folder.
       install -m 644 gadget-"${CRAFT_ARCH_BUILD_FOR}".yaml "${CRAFT_PROJECT_DIR}"/gadget.yaml
+  cloud-init:
+    plugin: nil
+    source: .
+    override-build: |
+      install -m 644 cloud.conf "${CRAFT_PART_INSTALL}"/cloud.conf


### PR DESCRIPTION
* feat(GCE): Rename the original pc-gadget and add the GCE datasource
* docs/chores: Update the .gitignore and README.md files
* test: add github action to build snap on PRs (cherry-pick)
* docs: add license field to snapcraft.yaml (cherry-pick)

(thanks again to `danpdraper` and `toabctl`)