### PR TITLE
feat(GCE): Build for both AMD64 and ARM64

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -10,6 +10,10 @@ grade: stable
 icon: icon.png
 license: GPL-3.0-or-later
 
+platforms:
+  amd64:
+  arm64:
+
 #package-repositories:
 # - type: apt
 #   ppa: ucdev/uc-staging-ppa


### PR DESCRIPTION
AMD64 and ARM64 are the two architectures supported in GCE so far. ARM64 was not explicitly stated yet so we should add it here as well.