### PR TITLE
feat(GCE): set MOTD via install-device hook

### DIFF
--- a/snap/hooks/install-device
+++ b/snap/hooks/install-device
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -eu
+
+MOTD_DIR=/run/mnt/ubuntu-data/system-data/_writable_defaults/etc/motd.d
+
+mkdir -p "$MOTD_DIR"
+cat > "$MOTD_DIR/50-default" <<'EOF'
+testing
+EOF

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -10,6 +10,12 @@ grade: stable
 icon: icon.png
 license: GPL-3.0-or-later
 
+plugs:
+  motddir:
+    interface: system-files
+    write:
+      - /run/mnt/ubuntu-data/system-data/_writable_defaults/etc/motd.d
+
 platforms:
   amd64:
   arm64:


### PR DESCRIPTION
Add motddir system-files plug for _writable_defaults motd.d. Create install-device hook that writes testing to motd 50-default on first boot.