### PR TITLE
feat(GCE): Set custom MOTD via cloud-init for core

### DIFF
--- a/cloud.conf
+++ b/cloud.conf
@@ -3,13 +3,24 @@ datasource:
   GCE:
     sec_between_retries: 5
 
-# runcmd:
-#   - [ bash, -lc, "mkdir -p /etc/motd.d && ln -sf /dev/null /etc/motd.d/50-default" ]
+runcmd:
+  - [ bash, -lc, "mkdir -p /etc/motd.d && ln -sf /dev/null /etc/motd.d/50-default" ]
 
-# write_files:
-#   - path: /etc/motd.d/99-custom-google-cloud
-#     owner: root:root
-#     permissions: "0644"
-#     defer: true
-#     content: |
-#       HELLO FROM CORE ON GOOGLE CLOUD!
+write_files:
+  - path: /etc/motd.d/99-custom-google-cloud
+    owner: root:root
+    permissions: "0644"
+    defer: true
+    content: |
+      Welcome to Ubuntu Core 24
+
+      * Documentation: https://ubuntu.com/core/docs
+
+      This is a pre-built Ubuntu Core image. Pre-built images are ideal for
+      exploration as you develop your own custom Ubuntu Core image.
+
+      To learn how to create your custom Ubuntu Core image, see our guide:
+
+      * Getting Started: https://ubuntu.com/core/docs/get-started
+
+      * First steps: https://ubuntu.com/core/docs/first-steps

--- a/cloud.conf
+++ b/cloud.conf
@@ -2,3 +2,14 @@
 datasource:
   GCE:
     sec_between_retries: 5
+
+# runcmd:
+#   - [ bash, -lc, "mkdir -p /etc/motd.d && ln -sf /dev/null /etc/motd.d/50-default" ]
+
+# write_files:
+#   - path: /etc/motd.d/99-custom-google-cloud
+#     owner: root:root
+#     permissions: "0644"
+#     defer: true
+#     content: |
+#       HELLO FROM CORE ON GOOGLE CLOUD!

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: gce-gadget
-version: '24-0.1'
+version: '24-0.2'
 type: gadget
 base: core24
 summary: GCE gadget for instances launched in Google Cloud


### PR DESCRIPTION
- Add cloud-init runcmd to disable default MOTD entry
- Add write_files to create /etc/motd.d/99-custom-google-cloud with custom text