### PR TITLE
feat: Add specific config/connections for `gce-guest-suite`

### DIFF
--- a/cloud.conf
+++ b/cloud.conf
@@ -6,6 +6,14 @@ datasource:
 runcmd:
   - [ bash, -lc, "mkdir -p /etc/motd.d && ln -sf /dev/null /etc/motd.d/50-default" ]
 
+# Enable `linger` so the `ubuntu` user's `systemd` runs on boot (with no login)
+# This is required for snap user daemons and timers to run reliably on UC
+#  - [ loginctl, enable-linger, ubuntu ]
+
+# Ensure that `snapd`’s per-user session agent socket is actually active for the `ubuntu` user
+# `snapd` uses this to manage user-scoped services; without it installing and/or enabling snaps with `daemon-scope: user` set can fail
+#  - [ bash, -lc, 'UID=$(id -u ubuntu); systemctl start user@$UID.service; sudo -u ubuntu env XDG_RUNTIME_DIR=/run/user/$UID DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$UID/bus systemctl --user enable --now snapd.session-agent.socket' ]
+
 write_files:
   - path: /etc/motd.d/99-custom-google-cloud
     owner: root:root

--- a/gadget/gadget-amd64.yaml
+++ b/gadget/gadget-amd64.yaml
@@ -65,3 +65,25 @@ volumes:
         filesystem: ext4
         type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
         size: 1G
+
+defaults:
+  system:
+    experimental:
+      user-daemons: true
+
+#  ${GCE_GUEST_SUITE_SNAP_ID}:
+#    ssh:
+#      local-user: ubuntu
+#      sources: metadata
+#      merge-mode: merge
+#      managed-block-id: gce-guest-suite
+#      prune-grace: 6h
+#
+#connections:
+#  - plug: ${GCE_GUEST_SUITE_SNAP_ID}:authorized-keys
+#    slot: system:system-files
+#
+#  - plug: ${GCE_GUEST_SUITE_SNAP_ID}:guest-agent-config
+#    slot: system:system-files
+#
+#  - plug: ${GCE_GUEST_SUITE_SNAP_ID}:snapd-control

--- a/gadget/gadget-arm64.yaml
+++ b/gadget/gadget-arm64.yaml
@@ -46,3 +46,25 @@ volumes:
         filesystem: ext4
         type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
         size: 1G
+
+defaults:
+  system:
+    experimental:
+      user-daemons: true
+
+#  ${GCE_GUEST_SUITE_SNAP_ID}:
+#    ssh:
+#      local-user: ubuntu
+#      sources: metadata
+#      merge-mode: merge
+#      managed-block-id: gce-guest-suite
+#      prune-grace: 6h
+#
+#connections:
+#  - plug: ${GCE_GUEST_SUITE_SNAP_ID}:authorized-keys
+#    slot: system:system-files
+#
+#  - plug: ${GCE_GUEST_SUITE_SNAP_ID}:guest-agent-config
+#    slot: system:system-files
+#
+#  - plug: ${GCE_GUEST_SUITE_SNAP_ID}:snapd-control

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: gce-gadget
-version: '24-0.2'
+version: '24-0.3'
 type: gadget
 base: core24
 summary: GCE gadget for instances launched in Google Cloud


### PR DESCRIPTION
The SNAP_ID and `linger` customisations are currently commented out, pending acceptance and upload to the store when we'll receive a proper ID for the registered snap.