### PR TITLE
Add key sync details from the new-and-improves gce-guest-suite-core snap

### DIFF
--- a/cloud.conf
+++ b/cloud.conf
@@ -3,17 +3,6 @@ datasource:
   GCE:
     sec_between_retries: 5
 
-runcmd:
-  - [ bash, -lc, "mkdir -p /etc/motd.d && ln -sf /dev/null /etc/motd.d/50-default" ]
-
-# Enable `linger` so the `ubuntu` user's `systemd` runs on boot (with no login)
-# This is required for snap user daemons and timers to run reliably on UC
-#  - [ loginctl, enable-linger, ubuntu ]
-
-# Ensure that `snapd`’s per-user session agent socket is actually active for the `ubuntu` user
-# `snapd` uses this to manage user-scoped services; without it installing and/or enabling snaps with `daemon-scope: user` set can fail
-#  - [ bash, -lc, 'UID=$(id -u ubuntu); systemctl start user@$UID.service; sudo -u ubuntu env XDG_RUNTIME_DIR=/run/user/$UID DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$UID/bus systemctl --user enable --now snapd.session-agent.socket' ]
-
 write_files:
   - path: /etc/motd.d/99-custom-google-cloud
     owner: root:root
@@ -32,3 +21,56 @@ write_files:
       * Getting Started: https://ubuntu.com/core/docs/get-started
 
       * First steps: https://ubuntu.com/core/docs/first-steps
+
+  # ssh drop-in
+  # Tell sshd to _also_ read keys from the root-owned path `gce-guest-suite-core` snap's
+  # `ssh-key-sync` helper maintains. The user's own `~/.ssh/authorized_keys` file still
+  # works, this just adds a second system-managed source. `root` ownership of this path
+  # is on purpose (so a compromised user account can't edit it)
+
+  - path: /etc/ssh/sshd_config.d/10-gce-guest-suite-core-authkeys.conf
+    permissions: "0644"
+    content: |
+      AuthorizedKeysFile .ssh/authorized_keys /var/snap/gce-guest-suite-core/common/authorized_keys.d/%u
+
+
+  # GCE shutdown scripts
+  # The snap runs startup scripts as a snap oneshot daemon, but unfortunately
+  # snapd has no proper "run on host shutdown" hook. So shutdown scripts are delivered
+  # via a host systemd unit whose ExecStop fires the snap's script-runner when the
+  # unit is stopped at shutdown (also the same ExecStop workaround/trick the google
+  # upstream google-shutdown-scripts.service uses)
+  - path: /etc/systemd/system/gce-shutdown-scripts.service
+    permissions: "0644"
+    content: |
+      [Unit]
+      Description=GCE metadata shutdown scripts
+      Wants=network-online.target
+      After=network-online.target
+      [Service]
+      Type=oneshot
+      RemainAfterExit=true
+      # Does nothing on start, the real work runs on stop which
+      # `systemd` triggers during the shutdown transition because the unit is
+      # wanted by `multi-user.target` and `DefaultDependencies` adds an implicit
+      # `Conflicts=shutdown.target`. That implicit conflict is what causes the
+      # unit to be stopped (and `ExecStop` to go off) during shutdown
+      # TL;DR *do not* add `DefaultDependencies=no` here; it removes that
+      # implicit `Conflicts`
+      ExecStart=/bin/true
+      # Also, *do not* use `snap run gce-guest-suite-core.script-runner` here
+      # `snap run` requires `systemd` to start a transient `.scope` unit via `DBus`,
+      # which `systemd` refuses once `shutdown.target` and/or `poweroff.target` is queued up
+      # ("TransactionIsDestructive"). So we invoke the binary directly instead,
+      # this technically "breaks" snap confinement for the transient shutdown-script process
+      # but that's okay as 1) it runs only at shutdown for a boxed amount of time and
+      # 2) all it does is HTTP-fetch metadata and exec a shell script anyways
+      ExecStop=/snap/gce-guest-suite-core/current/bin/google_metadata_script_runner shutdown
+      TimeoutStopSec=120
+      KillMode=process
+      [Install]
+      WantedBy=multi-user.target
+
+runcmd:
+  - [ systemctl, daemon-reload ]
+  - [ systemctl, enable, gce-shutdown-scripts.service ]

--- a/gadget/gadget-amd64.yaml
+++ b/gadget/gadget-amd64.yaml
@@ -74,10 +74,9 @@ defaults:
   # Now we've redesigned `ssh-key-sync` in the `gce-guest-suite-core` snap it no longer
   # uses the super-privileged `system-files` interface. Instead the `ssh-key-sync` helper writes
   # to its own `$SNAP_COMMON` dir and we point sshd at it via the (shipped here) cloud.conf
-  # The remaining "manual" interface is `hostname-control`, which will connect automatically
-  # from here when we have a proper ID for the gce-guest-suite-core snap (i.e. when it's finally published)
-  # TL;DR uncomment below and add the output of `snap info gce-guest-suite-core` when it's published
+  # The remaining "manual" interface is `hostname-control` which will connect automatically
+  # below
 
-# connections:
-#   - plug: <GCE_GUEST_SNAP_ID>:hostname-control
-#     slot: system:hostname-control
+connections:
+ - plug: pFW262Ov8qp7QiCyKftmv5VlBfDxhBN2:hostname-control
+   slot: system:hostname-control

--- a/gadget/gadget-amd64.yaml
+++ b/gadget/gadget-amd64.yaml
@@ -71,19 +71,13 @@ defaults:
     experimental:
       user-daemons: true
 
-#  ${GCE_GUEST_SUITE_SNAP_ID}:
-#    ssh:
-#      local-user: ubuntu
-#      sources: metadata
-#      merge-mode: merge
-#      managed-block-id: gce-guest-suite
-#      prune-grace: 6h
-#
-#connections:
-#  - plug: ${GCE_GUEST_SUITE_SNAP_ID}:authorized-keys
-#    slot: system:system-files
-#
-#  - plug: ${GCE_GUEST_SUITE_SNAP_ID}:guest-agent-config
-#    slot: system:system-files
-#
-#  - plug: ${GCE_GUEST_SUITE_SNAP_ID}:snapd-control
+  # Now we've redesigned `ssh-key-sync` in the `gce-guest-suite-core` snap it no longer
+  # uses the super-privileged `system-files` interface. Instead the `ssh-key-sync` helper writes
+  # to its own `$SNAP_COMMON` dir and we point sshd at it via the (shipped here) cloud.conf
+  # The remaining "manual" interface is `hostname-control`, which will connect automatically
+  # from here when we have a proper ID for the gce-guest-suite-core snap (i.e. when it's finally published)
+  # TL;DR uncomment below and add the output of `snap info gce-guest-suite-core` when it's published
+
+# connections:
+#   - plug: <GCE_GUEST_SNAP_ID>:hostname-control
+#     slot: system:hostname-control

--- a/gadget/gadget-arm64.yaml
+++ b/gadget/gadget-arm64.yaml
@@ -55,10 +55,9 @@ defaults:
   # Now we've redesigned `ssh-key-sync` in the `gce-guest-suite-core` snap it no longer
   # uses the super-privileged `system-files` interface. Instead the `ssh-key-sync` helper writes
   # to its own `$SNAP_COMMON` dir and we point sshd at it via the (shipped here) cloud.conf
-  # The remaining "manual" interface is `hostname-control`, which will connect automatically
-  # from here when we have a proper ID for the gce-guest-suite-core snap (i.e. when it's finally published)
-  # TL;DR uncomment below and add the output of `snap info gce-guest-suite-core` when it's published
+  # The remaining "manual" interface is `hostname-control` which will connect automatically
+  # below
 
-# connections:
-#   - plug: <GCE_GUEST_SNAP_ID>:hostname-control
-#     slot: system:hostname-control
+connections:
+ - plug: pFW262Ov8qp7QiCyKftmv5VlBfDxhBN2:hostname-control
+   slot: system:hostname-control

--- a/gadget/gadget-arm64.yaml
+++ b/gadget/gadget-arm64.yaml
@@ -52,19 +52,13 @@ defaults:
     experimental:
       user-daemons: true
 
-#  ${GCE_GUEST_SUITE_SNAP_ID}:
-#    ssh:
-#      local-user: ubuntu
-#      sources: metadata
-#      merge-mode: merge
-#      managed-block-id: gce-guest-suite
-#      prune-grace: 6h
-#
-#connections:
-#  - plug: ${GCE_GUEST_SUITE_SNAP_ID}:authorized-keys
-#    slot: system:system-files
-#
-#  - plug: ${GCE_GUEST_SUITE_SNAP_ID}:guest-agent-config
-#    slot: system:system-files
-#
-#  - plug: ${GCE_GUEST_SUITE_SNAP_ID}:snapd-control
+  # Now we've redesigned `ssh-key-sync` in the `gce-guest-suite-core` snap it no longer
+  # uses the super-privileged `system-files` interface. Instead the `ssh-key-sync` helper writes
+  # to its own `$SNAP_COMMON` dir and we point sshd at it via the (shipped here) cloud.conf
+  # The remaining "manual" interface is `hostname-control`, which will connect automatically
+  # from here when we have a proper ID for the gce-guest-suite-core snap (i.e. when it's finally published)
+  # TL;DR uncomment below and add the output of `snap info gce-guest-suite-core` when it's published
+
+# connections:
+#   - plug: <GCE_GUEST_SNAP_ID>:hostname-control
+#     slot: system:hostname-control

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: gce-gadget
-version: '26-0.2'
+version: '26-0.3'
 type: gadget
 base: core26
 summary: GCE gadget for instances launched in Google Cloud


### PR DESCRIPTION
Edited `cloud.conf` to ship an `sshd` drop-in that points `AuthorizedKeysFile` at the gce-guest-suite-core helper's key path (`/var/snap/gce-guest-suite-core/common/authorized_keys.d/%u`). This replaces the earlier `enable-linger` approach needed in the old `ssh-key-sync` golang helper.

Also as the snap is in the store we can uncomment the `connections` snippet and add the IDs.

